### PR TITLE
style: 마이페이지 내 수정버튼,전체보기버튼 수정 및 스크롤영역 지정

### DIFF
--- a/css/my-page.css
+++ b/css/my-page.css
@@ -54,6 +54,7 @@
 }
 
 body {
+  display: flex;
   flex-direction: column;
 }
 
@@ -70,14 +71,13 @@ body {
   flex-direction: column;
   width: 100%;
   min-width: 240px;
-  justify-content: center;
-  align-items: center;
 }
 .main-wrap .profile-section {
+  position: sticky;
   width: 100%;
   margin-top: 95px;
   background-color: var(--color-background);
-  padding: 3rem 0;
+  padding: 2rem 0;
 }
 .main-wrap .profile-section .profile-wrap {
   width: 70%;

--- a/css/my-page.css
+++ b/css/my-page.css
@@ -65,6 +65,7 @@ body {
 }
 
 .main-wrap {
+  min-height: calc(100vh - 149px);
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -121,17 +122,10 @@ body {
   color: var(--font-basic-color);
 }
 .main-wrap .profile-section .profile-wrap .profile-edit .edit-btn {
-  padding: 0.7rem 1.5rem;
-  background-color: var(--color-orange);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: var(--font-medium-size);
+  padding: 0;
+  color: var(--font-basic-color);
+  font-size: var(--font-small-size);
   cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-.main-wrap .profile-section .profile-wrap .profile-edit .edit-btn:hover {
-  background-color: #ff8510;
 }
 .main-wrap .mypage-contents {
   width: 100%;
@@ -179,21 +173,9 @@ body {
 }
 .main-wrap .mypage-contents .tab-container .tab-content .tab-pane .section-top {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   margin-bottom: 1.5rem;
-}
-.main-wrap .mypage-contents .tab-container .tab-content .tab-pane .section-top h2 {
-  font-size: var(--font-xlarge-size);
-  font-weight: var(--font-bold);
-  color: var(--font-basic-color);
-}
-.main-wrap .mypage-contents .tab-container .tab-content .tab-pane .section-top .view-all a {
-  color: var(--color-orange);
-  font-size: var(--font-medium-size);
-}
-.main-wrap .mypage-contents .tab-container .tab-content .tab-pane .section-top .view-all a:hover {
-  text-decoration: underline;
 }
 .main-wrap .mypage-contents .tab-container .tab-content .tab-pane .content-container {
   display: flex;

--- a/css/my-page.css
+++ b/css/my-page.css
@@ -53,6 +53,10 @@
   --border-radius: 0.5rem;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -167,6 +171,7 @@ body {
 }
 .main-wrap .mypage-contents .tab-container .tab-content .tab-pane {
   display: none;
+  min-height: 300px;
 }
 .main-wrap .mypage-contents .tab-container .tab-content .tab-pane.active {
   display: block;
@@ -188,6 +193,7 @@ body {
   max-height: 60vh;
   overflow-y: auto;
   padding-right: 1rem;
+  scrollbar-gutter: stable;
   /* 스크롤바 스타일링 */
 }
 .main-wrap .mypage-contents .tab-container .tab-content .tab-pane .content-container .content-list::-webkit-scrollbar {
@@ -389,6 +395,9 @@ body {
   .main-wrap .profile-section .profile-wrap .profile-info {
     flex-direction: column;
     text-align: center;
+  }
+  .main-wrap .mypage-contents {
+    flex-grow: 1;
   }
   .main-wrap .mypage-contents .tab-container {
     width: 90%;

--- a/pages/my-page/my-page.html
+++ b/pages/my-page/my-page.html
@@ -43,15 +43,10 @@
             <div class="tab-content">
               <!-- 북마크한 공모전 탭 -->
               <div class="tab-pane active" id="bookmarks">
-                <div class="section-top">
-                  <h2>북마크한 공모전</h2>
-                  <div class="view-all">
-                    <a href="#">전체보기</a>
-                  </div>
-                </div>
+                <div class="section-top"></div>
                 <div class="content-container">
                   <ul class="content-list" id="bookmark-list">
-                    <!-- 북마크한 공모전 목록이 여기에 표시됩니다 -->
+                    <!-- 북마크한 공모전 목록 -->
                   </ul>
                   <div class="load-more">
                     <button id="load-more-bookmarks" class="load-more-btn">더 보기</button>
@@ -61,15 +56,10 @@
 
               <!-- 공모전 신청 현황 탭 -->
               <div class="tab-pane" id="applications">
-                <div class="section-top">
-                  <h2>공모전 신청 현황</h2>
-                  <div class="view-all">
-                    <a href="#">전체보기</a>
-                  </div>
-                </div>
+                <div class="section-top"></div>
                 <div class="content-container">
                   <ul class="content-list" id="application-list">
-                    <!-- 공모전 신청 현황 목록이 여기에 표시됩니다 -->
+                    <!-- 공모전 신청 현황 목록 -->
                   </ul>
                   <div class="load-more">
                     <button id="load-more-applications" class="load-more-btn">더 보기</button>
@@ -79,15 +69,10 @@
 
               <!-- 내가 쓴 글 탭 -->
               <div class="tab-pane" id="my-posts">
-                <div class="section-top">
-                  <h2>내가 쓴 글</h2>
-                  <div class="view-all">
-                    <a href="#">전체보기</a>
-                  </div>
-                </div>
+                <div class="section-top"></div>
                 <div class="content-container">
                   <ul class="content-list" id="my-posts-list">
-                    <!-- 내가 쓴 글 목록이 여기에 표시됩니다 -->
+                    <!-- 내가 쓴 글 목록 -->
                   </ul>
                   <div class="load-more">
                     <button id="load-more-posts" class="load-more-btn">더 보기</button>

--- a/sass/my-page/my-page.scss
+++ b/sass/my-page/my-page.scss
@@ -13,6 +13,7 @@ body {
 }
 
 .main-wrap {
+  min-height: calc(100vh - 149px);
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -77,18 +78,10 @@ body {
 
       .profile-edit {
         .edit-btn {
-          padding: 0.7rem 1.5rem;
-          background-color: var(--color-orange);
-          color: white;
-          border: none;
-          border-radius: 8px;
-          font-size: var(--font-medium-size);
+          padding: 0;
+          color: var(--font-basic-color);
+          font-size: var(--font-small-size);
           cursor: pointer;
-          transition: background-color 0.3s ease;
-
-          &:hover {
-            background-color: darken(#ff9f43, 10%);
-          }
         }
       }
     }
@@ -148,26 +141,9 @@ body {
 
           .section-top {
             display: flex;
-            justify-content: space-between;
+            justify-content: center;
             align-items: center;
             margin-bottom: 1.5rem;
-
-            h2 {
-              font-size: var(--font-xlarge-size);
-              font-weight: var(--font-bold);
-              color: var(--font-basic-color);
-            }
-
-            .view-all {
-              a {
-                color: var(--color-orange);
-                font-size: var(--font-medium-size);
-
-                &:hover {
-                  text-decoration: underline;
-                }
-              }
-            }
           }
 
           .content-container {

--- a/sass/my-page/my-page.scss
+++ b/sass/my-page/my-page.scss
@@ -1,6 +1,10 @@
 @use "../../assets/fonts/font";
 @use "../common/variables";
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -134,6 +138,7 @@ body {
 
         .tab-pane {
           display: none;
+          min-height: 300px;
 
           &.active {
             display: block;
@@ -157,6 +162,7 @@ body {
               max-height: 60vh;
               overflow-y: auto;
               padding-right: 1rem;
+              scrollbar-gutter: stable;
 
               /* 스크롤바 스타일링 */
               &::-webkit-scrollbar {
@@ -406,6 +412,7 @@ body {
     }
 
     .mypage-contents {
+      flex-grow: 1;
       .tab-container {
         width: 90%;
 

--- a/sass/my-page/my-page.scss
+++ b/sass/my-page/my-page.scss
@@ -2,6 +2,7 @@
 @use "../common/variables";
 
 body {
+  display: flex;
   flex-direction: column;
 }
 
@@ -18,15 +19,14 @@ body {
   flex-direction: column;
   width: 100%;
   min-width: 240px;
-  justify-content: center;
-  align-items: center;
 
   // 프로필 섹션
   .profile-section {
+    position: sticky;
     width: 100%;
     margin-top: 95px;
     background-color: var(--color-background);
-    padding: 3rem 0;
+    padding: 2rem 0;
 
     .profile-wrap {
       width: 70%;


### PR DESCRIPTION
## 🔗 관련 이슈 번호
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 파일
css/my-page.css
pages/my-page/my-page.html
sass/my-page/my-page.scss

## 📝 작업한 내용
프로필 내의 프로필수정버튼 스타일 수정
탭 내부 전체보기 삭제
스크롤바영역 항상 표시로 헤더,푸터가 스크롤바에 따라 밀리지 않게 임시조정

## ✏️ 필요한 후속 작업
탭전환에 따라 스크롤바가 생기면 헤더/푸터가 밀려버리는 현상 때문에 일단 stable로 처리해두었으나 스크롤바를 오버레이로 띄울 방법이 없는지 탐색해봐야 할 것 같습니다

## 🔎 참고 자료

## ⌨️ 코드리뷰

